### PR TITLE
Let new change|input event bubble

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -5,7 +5,7 @@ export function trigger(element, type) {
     }
 
     // Create and dispatch the event
-    const event = new Event(type);
+    const event = new Event(type, { bubbles: true });
 
     // Dispatch the event
     element.dispatchEvent(event);


### PR DESCRIPTION
When using this library with React, it does not work as expected when the change|input event does not bubbles. According to specs, both input and change events should bubble by default https://www.w3.org/TR/uievents

fixes: https://github.com/sampotts/rangetouch/issues/7