### PR TITLE
Fix issues with `matches` function

### DIFF
--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -1,6 +1,6 @@
 // Element matches a selector
 export function matches(element, selector) {
-    const prototype = { Element };
+    const prototype = Element.prototype;
 
     function match() {
         return Array.from(document.querySelectorAll(selector)).includes(this);


### PR DESCRIPTION
The prototype of `Element` is `Element.prototype`, not `{ Element }`.